### PR TITLE
feat: dockerise services and add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Go CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: "on"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.24.x"
+
+      - name: Verify Go version
+        run: go version
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test ./... -v

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,41 @@
+name: Integration Tests CI
+
+on:
+  push:
+    branches: [main, docker]
+  pull_request:
+    branches: [main]
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    services:
+      docker:
+        image: docker:24.0.2-dind
+        options: --privileged
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and run services
+        run: docker compose up --build -d
+
+      - name: Wait for services to become healthy
+        run: |
+          for i in {1..10}; do
+            curl -s http://localhost:8080/health && break
+            echo "Waiting for gateway..."
+            sleep 3
+          done
+
+      - name: Test /convert endpoint
+        run: |
+          curl --fail "http://localhost:8080/convert?from=USD&to=EUR&amount=100"
+
+      - name: Tear down
+        if: always()
+        run: docker compose down --volumes --remove-orphans

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Go CI
+name: Unit Tests CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 # Go FX Micro-Playground 💱
 
 A tiny Go project designed to explore microservices architecture, with a working example of currency conversion.
@@ -19,9 +17,30 @@ go-fx-micro-playground/
 
 ## 🚀 Running the Services
 
+### 🐳 With Docker Compose (Recommended)
+
+Spin up both services with:
+
+```bash
+docker compose up --build
+```
+
+Then access:
+- `http://localhost:8081/health` for the Rates service
+- `http://localhost:8080/convert?from=USD&to=EUR&amount=100` for currency conversion
+
+To stop and clean up:
+```bash
+docker compose down --volumes --remove-orphans
+```
+
+---
+
+### 🧪 Dev Without Docker
+
 In two terminals:
 
-```
+```bash
 go run services/rates/main.go
 go run services/gateway/main.go
 ```
@@ -57,11 +76,15 @@ Example response:
 
 ## 💡 Future Plans
 
-- Dockerize services with `docker-compose`  
 - Add live FX rate updates from an external API  
 - Generate Swagger/OpenAPI documentation  
 
 ## 🧪 Testing
+
+**CI Workflows**
+
+- Unit tests are run automatically on every PR and push to `main` via GitHub Actions.
+- Docker-based integration tests validate the containerised services and `/convert` endpoint.
 
 **Unit tests**  
 Run all unit tests for both services with:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Example response:
 
 - Dockerize services with `docker-compose`  
 - Add live FX rate updates from an external API  
-- Set up CI/CD pipeline (GitHub Actions) for automated testing  
 - Generate Swagger/OpenAPI documentation  
 
 ## 🧪 Testing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+
+
+version: "3.8"
+
+services:
+  rates:
+    image: fx-rates
+    build:
+      context: .
+      dockerfile: services/rates/Dockerfile
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:8081/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  gateway:
+    image: fx-gateway
+    build:
+      context: .
+      dockerfile: services/gateway/Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      rates:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/JackIABishop/go-fx-micro-playground
 
-go 1.24.2
+go 1.24

--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -1,0 +1,33 @@
+
+
+# Build stage
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+
+# Copy go mod files and download deps
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the full source code (to resolve internal/logging, etc.)
+COPY . .
+
+# Set working directory to the gateway service
+WORKDIR /app/services/gateway
+RUN go build -o gateway .
+
+# Final runtime stage
+FROM alpine:latest
+WORKDIR /root/
+
+# Copy the compiled binary
+COPY --from=builder /app/services/gateway/gateway .
+
+# Expose the service port
+EXPOSE 8080
+
+# Healthcheck for container orchestration
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 \
+  CMD wget --no-verbose --spider http://localhost:8080/health || exit 1
+
+# Run the service
+CMD ["./gateway"]

--- a/services/gateway/main.go
+++ b/services/gateway/main.go
@@ -31,7 +31,7 @@ func handleConvert(w http.ResponseWriter, r *http.Request) {
 	logging.Logger.Printf("💬 Received conversion request: from=%s to=%s amount=%f", from, to, amount)
 
 	// Call the /rates endpoint from the rates service to get current currency rates
-	resp, err := http.Get("http://localhost:8081/rates")
+	resp, err := http.Get("http://rates:8081/rates")
 	if err != nil {
 		logging.Logger.Printf("❌ Error contacting rates service: %v", err)
 		http.Error(w, "❌ Failed to contact rates service", http.StatusInternalServerError)

--- a/services/rates/Dockerfile
+++ b/services/rates/Dockerfile
@@ -1,0 +1,31 @@
+
+
+# Build stage
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+
+# Cache module downloads
+COPY go.mod ./
+RUN go mod download
+
+# Copy service code and build
+COPY . .
+WORKDIR /app/services/rates
+RUN go build -o rates .
+
+# Final runtime stage
+FROM alpine:latest
+WORKDIR /root/
+
+# Copy the compiled binary
+COPY --from=builder /app/services/rates/rates .
+
+# Expose the service port
+EXPOSE 8081
+
+# Healthcheck for container orchestration
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 \
+  CMD wget --no-verbose --spider http://localhost:8081/health || exit 1
+
+# Run the service
+CMD ["./rates"]


### PR DESCRIPTION
This PR introduces:

- 🐳 `.github/workflows/unit-tests.yml` to run Go Unit Tests tests on push/PR (Closes #3)  
- 🐳 `services/rates/Dockerfile` for the Rates service (Closes #1)  
- 🐳 `services/gateway/Dockerfile` for the Gateway service (Closes #1)  
- 🐳 `docker-compose.yml` to orchestrate both services (Closes #2)  
- 🐳 `github/workflows/integration-tests.yml` to run Docker tests on push/PR

After merging, we’ll have automated tests running on every PR and fully containerised services ready for local or CI use.